### PR TITLE
Commands like cat parsed | grep l2_block_end | wc -l

### DIFF
--- a/datastreamer/proto.go
+++ b/datastreamer/proto.go
@@ -1,0 +1,104 @@
+package datastreamer
+
+import (
+	"fmt"
+	"github.com/0xPolygonHermez/zkevm-data-streamer/datastream"
+	"google.golang.org/protobuf/proto"
+)
+
+func UnmarshalBookMark(data []byte) (*datastream.BookMark, error) {
+	bookmark := &datastream.BookMark{}
+	if err := proto.Unmarshal(data, bookmark); err != nil {
+		return nil, err
+	}
+	return bookmark, nil
+}
+
+func UnmarshalGerUpdate(data []byte) (*datastream.UpdateGER, error) {
+	update := &datastream.UpdateGER{}
+	if err := proto.Unmarshal(data, update); err != nil {
+		return nil, err
+	}
+	return update, nil
+}
+
+func UnmarshalBatchStart(data []byte) (*datastream.BatchStart, error) {
+	batch := &datastream.BatchStart{}
+	if err := proto.Unmarshal(data, batch); err != nil {
+		return nil, err
+	}
+	return batch, nil
+}
+
+func UnmarshalBatchEnd(data []byte) (*datastream.BatchEnd, error) {
+	batch := &datastream.BatchEnd{}
+	if err := proto.Unmarshal(data, batch); err != nil {
+		return nil, err
+	}
+	return batch, nil
+}
+
+func UnmarshalL2Block(data []byte) (*datastream.L2Block, error) {
+	block := &datastream.L2Block{}
+	if err := proto.Unmarshal(data, block); err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+func UnmarshalL2BlockEnd(data []byte) (*datastream.L2BlockEnd, error) {
+	block := &datastream.L2BlockEnd{}
+	if err := proto.Unmarshal(data, block); err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+func UnmarshalTransaction(data []byte) (*datastream.Transaction, error) {
+	tx := &datastream.Transaction{}
+	if err := proto.Unmarshal(data, tx); err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+func parseFileEntry(entryType EntryType, data []byte) (interface{}, error) {
+	switch entryType {
+	case EntryType(datastream.EntryType_ENTRY_TYPE_TRANSACTION):
+		return UnmarshalTransaction(data)
+	//case EntryType(1):
+	//	return UnmarshalBookMark(data)
+	case EntryType(datastream.EntryType_ENTRY_TYPE_L2_BLOCK):
+		return UnmarshalL2Block(data)
+	case EntryType(datastream.EntryType_ENTRY_TYPE_L2_BLOCK_END):
+		return UnmarshalL2BlockEnd(data)
+	case EntryType(datastream.EntryType_ENTRY_TYPE_BATCH_START):
+		return UnmarshalBatchStart(data)
+	case EntryType(datastream.EntryType_ENTRY_TYPE_BATCH_END):
+		return UnmarshalBatchEnd(data)
+	case EntryType(datastream.EntryType_ENTRY_TYPE_UPDATE_GER):
+		return UnmarshalGerUpdate(data)
+	default:
+		return nil, fmt.Errorf("unknown entry type: %d", entryType)
+	}
+}
+
+func (e EntryType) String() string {
+	switch e {
+	case EntryType(datastream.EntryType_ENTRY_TYPE_TRANSACTION):
+		return "transaction"
+
+	case EntryType(datastream.EntryType_ENTRY_TYPE_L2_BLOCK):
+		return "l2_block"
+	case EntryType(datastream.EntryType_ENTRY_TYPE_L2_BLOCK_END):
+		return "l2_block_end"
+	case EntryType(datastream.EntryType_ENTRY_TYPE_BATCH_START):
+		return "batch_start"
+	case EntryType(datastream.EntryType_ENTRY_TYPE_BATCH_END):
+		return "batch_end"
+	case EntryType(datastream.EntryType_ENTRY_TYPE_UPDATE_GER):
+		return "update_ger"
+	default:
+		return "unknown"
+	}
+}

--- a/datastreamer/streamfile.go
+++ b/datastreamer/streamfile.go
@@ -3,6 +3,7 @@ package datastreamer
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -1077,4 +1078,21 @@ func (f *StreamFile) truncateFile(entryNum uint64) error {
 	}
 
 	return nil
+}
+
+func (f *StreamFile) WriteParsedFileContents(writer io.Writer) (err error) {
+	var it *iteratorFile
+	var endOfEntries bool
+
+	for it, err = f.iteratorFrom(0, true); !endOfEntries && err == nil; endOfEntries, err = f.iteratorNext(it) {
+		if parsedEntry, err := parseFileEntry(it.Entry.Type, it.Entry.Data); err == nil {
+			if s, ok := parsedEntry.(fmt.Stringer); ok {
+				writer.Write([]byte(it.Entry.Type.String() + "{ "))
+				_, err = writer.Write([]byte(s.String() + " }\n\n"))
+			} else {
+				err = fmt.Errorf("unparseable entry: %d", it.Entry.Type)
+			}
+		}
+	}
+	return err
 }

--- a/datastreamer/streamfile_test.go
+++ b/datastreamer/streamfile_test.go
@@ -54,3 +54,47 @@ func TestWriteAndReadHeader(t *testing.T) {
 	assert.Equal(t, uint64(10), sf.header.TotalEntries)
 	assert.Equal(t, uint64(4096), sf.header.TotalLength)
 }
+
+func preTestWriteParsedFileContents(streamFileName string, parsedFileName string) (*StreamFile, *os.File, error) {
+	streamFile, err := NewStreamFile(streamFileName, 1, 137, 1)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = os.Stat(parsedFileName)
+	if err == nil {
+		if err = os.Remove(parsedFileName); err != nil {
+			return nil, nil, err
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	var outputFile *os.File
+	if outputFile, err = os.Create(parsedFileName); err != nil {
+		return nil, nil, err
+	}
+	return streamFile, outputFile, nil
+}
+
+func postTestWriteParsedFileContents(parsedFileName string) error {
+	if _, err := os.Stat(parsedFileName); err == nil {
+		return os.Remove(parsedFileName)
+	}
+	return nil
+}
+
+func TestWriteParsedFileContents(t *testing.T) {
+	const parsedFilePath = "../testdata/parsed"
+	const streamFilePath = "../testdata/datarelay.bin"
+	streamFile, outputFile, err := preTestWriteParsedFileContents(streamFilePath, parsedFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = streamFile.WriteParsedFileContents(outputFile); err != nil {
+		panic(err)
+	}
+
+	//if err = postTestWriteParsedFileContents(parsedFilePath); err != nil {
+	//	t.Fatal(err)
+	//}
+}


### PR DESCRIPTION
Allow us to perform parsing of datastream files so they are readable. Example when pulling files from server